### PR TITLE
CHEF-25310 - quick-archive - add_archive_note_to_readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+# Archived Repository
+
+This repository has been archived and will no longer receive updates. 
+It was archived as part of the [Repository Standardization Initiative](https://github.com/chef-boneyard/oss-repo-standardization-2025).
+If you are a Chef customer and need support for this repository, please contact your Chef account team.
+
+
 # Learn Chef AWS InSpec profile
 
 This InSpec profile is for the Learn Chef module [Secure AWS resources with InSpec](https://learn.chef.io/modules/inspec-aws-cloud/). The module explores using InSpec to verify AWS resources created through Terraform.


### PR DESCRIPTION
This PR adds an archive notice to the top of the README to indicate that this repository is being archived as part of the Repository Standardization Initiative.
The note informs users that the repository will no longer receive updates and provides guidance for Chef customers seeking support.